### PR TITLE
Re-theme site to remove all red

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -95,7 +95,7 @@ h6, .h6 { font-size: 0.75rem; }
 
 .list-reset { list-style: none; padding-left: 0; }
 
-.button-blue { color: white; background-color: #ef476f; border-radius: 3px; transition-duration: .1s; transition-timing-function: ease-out; transition-property: box-shadow, background-color; }
+.button-blue { color: white; background-color: #118ab2; border-radius: 3px; transition-duration: .1s; transition-timing-function: ease-out; transition-property: box-shadow, background-color; }
 
 .button-blue:hover { opacity: .875; }
 
@@ -115,9 +115,9 @@ h6, .h6 { font-size: 0.75rem; }
 
 .highlight .mi, .highlight .il { color: #009f06; }
 
-.highlight .s, .highlight .sb, .highlight .sc, .highlight .sd, .highlight .s2, .highlight .s3, .highlight .sh, .highlight .si, .highlight .sx, .highlight .sr, .highlight .ss, .highlight .s1 { color: #ff3636; }
+.highlight .s, .highlight .sb, .highlight .sc, .highlight .sd, .highlight .s2, .highlight .s3, .highlight .sh, .highlight .si, .highlight .sx, .highlight .sr, .highlight .ss, .highlight .s1 { color: #b45309; }
 
-.hljs-title, .hljs-id, .scss .hljs-preprocessor { color: #ff3636; font-weight: bold; }
+.hljs-title, .hljs-id, .scss .hljs-preprocessor { color: #b45309; font-weight: bold; }
 
 .highlight .k { font-weight: normal; }
 
@@ -135,7 +135,7 @@ h6, .h6 { font-size: 0.75rem; }
 
 .hljs-preprocessor, .hljs-pragma, .hljs-pi, .hljs-doctype, .hljs-shebang, .hljs-cdata { color: #666; font-weight: bold; }
 
-.hljs-deletion { background: #ffdddd; }
+.hljs-deletion { background: #fdebd0; }
 
 .hljs-addition { background: #ddffdd; }
 
@@ -146,7 +146,7 @@ h6, .h6 { font-size: 0.75rem; }
 /* Basscss Color Base */
 body { color: #333; background-color: white; }
 
-a { color: #ef476f; text-decoration: none; }
+a { color: #118ab2; text-decoration: none; }
 
 a:hover { text-decoration: underline; }
 
@@ -167,7 +167,7 @@ hr { border: 0; border-bottom-style: solid; border-bottom-width: 1px; border-bot
 
 .lighter-gray { color: #eee; }
 
-.red { color: #ff3636; }
+.red { color: #b45309; }
 
 .green { color: #00ab37; }
 
@@ -187,7 +187,7 @@ hr { border: 0; border-bottom-style: solid; border-bottom-width: 1px; border-bot
 
 .bg-lighter-gray { background-color: #eee; }
 
-.bg-red { background-color: #ff3636; }
+.bg-red { background-color: #b45309; }
 
 .bg-green { background-color: #00ab37; }
 
@@ -357,7 +357,7 @@ body { box-sizing: border-box; -moz-box-sizing: border-box; -webkit-box-sizing: 
   .site-nav .page-link:not(:last-child) { margin-right: 0; } }
 
 .header-bar { border-bottom: 1px solid #ccc; font-size: 20px; display: block; opacity: 0.75; width: 100%; text-align: center; padding-top: 25px; padding-bottom: 4rem; line-height: 3em; z-index: 25; }
-.header-bar h1 { color: #ef476f; font-size: 75px; }
+.header-bar h1 { color: #118ab2; font-size: 75px; }
 .header-bar h2 { font-size: 25px; }
 
 .site { display: -webkit-box; display: -webkit-flex; display: -ms-flexbox; display: flex; -webkit-box-orient: vertical; -webkit-box-direction: normal; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; min-height: 100vh; }
@@ -366,7 +366,7 @@ body { box-sizing: border-box; -moz-box-sizing: border-box; -webkit-box-sizing: 
 
 footer { background-color: #118ab2; border-top: thin solid #828282; color: #ccc; font-size: 0.75rem; font-weight: 300; padding: 0.5rem; position: fixed; left: 0px; bottom: 0px; width: 100%; }
 footer a { color: #fff; }
-footer a:hover { color: #ef476f; }
+footer a:hover { color: #ffd166; }
 
 .page-content { padding: 100px 0; /* VERTICAL PADDING FOR TITLE ON EVERY PAGE */ }
 
@@ -424,7 +424,7 @@ footer a:hover { color: #ef476f; }
 
 .pagination .pagination-meta { overflow: hidden; }
 
-.pagination a:hover, .pagination a:focus { background: white; color: #ef476f; }
+.pagination a:hover, .pagination a:focus { background: white; color: #118ab2; }
 
 .pagination a:active { background: #f7f7f7; }
 
@@ -434,7 +434,7 @@ footer a:hover { color: #ef476f; }
 
 .button-disabled:hover, .button-disabled:active, .button-disabled:focus { cursor: not-allowed; background-color: #999; }
 
-.publications h2 { color: #ef476f; font-size: 32px; margin-bottom: 30px; text-align: center; }
+.publications h2 { color: #118ab2; font-size: 32px; margin-bottom: 30px; text-align: center; }
 
 .year { border-top: 1px solid #ccc; color: #ccc; margin: 0 -3em -2.5ex -2em; padding-top: 1ex; text-align: right; }
 
@@ -444,7 +444,7 @@ img[alt="paper_imgs"] { width: 140px; height: 140px; }
 .bibliography li { margin: 10px 0; position: relative; }
 .bibliography li span { display: block; }
 .bibliography li .title { font-weight: bolder; }
-.bibliography li .author a { border-bottom: 1px dashed #ef476f; }
+.bibliography li .author a { border-bottom: 1px dashed #118ab2; }
 .bibliography li .author a:hover { border-bottom-style: solid; text-decoration: none; }
 .bibliography li .author > em { border-bottom: 1px solid; font-style: normal; }
 .bibliography li a.abstract, .bibliography li a.bibtex { cursor: pointer; }
@@ -456,7 +456,7 @@ img[alt="paper_imgs"] { width: 140px; height: 140px; }
 .bibliography li span.abstract.hidden.open { border-color: #828282; }
 .bibliography abbr { position: absolute; left: -7em; }
 
-.star { color: #ef476f; font-style: normal; }
+.star { color: #118ab2; font-style: normal; }
 
 blockquote { border-left: 5px solid #7a7a7a; font-style: italic; margin-left: 0.5rem; padding: 0.5rem; }
 
@@ -488,7 +488,7 @@ figure > img { display: block; }
 
 figcaption { font-size: 0.875rem; }
 
-.blankbox { background: #ef476f; }
+.blankbox { background: #118ab2; }
 
 .img_row { /*height: $img-height;*/ width: 100%; overflow: hidden; box-sizing: border-box; }
 
@@ -507,13 +507,13 @@ figcaption { font-size: 0.875rem; }
 .gist .lines { width: 100%; }
 
 a { color: #828282; text-decoration: none; }
-a:hover { color: #ef476f; text-decoration: none; }
+a:hover { color: #118ab2; text-decoration: none; }
 
-article a, .news a { color: #ef476f; font-weight: 100; }
+article a, .news a { color: #118ab2; font-weight: 100; }
 article a:hover, .news a:hover { text-decoration: underline; }
 
 .social a { color: #828282; }
-.social a:hover { color: #ef476f; }
+.social a:hover { color: #118ab2; }
 
 .measure { margin: 0 auto; max-width: 42rem; }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -260,10 +260,10 @@ pre { margin-top: 0; margin-bottom: 0; font-family: "SFMono-Regular", Consolas, 
 .border-green-light { border-color: #a2cbac !important; }
 
 /* Use with .border to turn the border red */
-.border-red { border-color: #d73a49 !important; }
+.border-red { border-color: #b45309 !important; }
 
 /* Use with .border to turn the border red-light */
-.border-red-light { border-color: #cea0a5 !important; }
+.border-red-light { border-color: #e0b48a !important; }
 
 /* Use with .border to turn the border purple */
 .border-purple { border-color: #6f42c1 !important; }
@@ -516,10 +516,10 @@ pre { margin-top: 0; margin-bottom: 0; font-family: "SFMono-Regular", Consolas, 
 .bg-green-light { background-color: #dcffe4 !important; }
 
 /* Set the background to $bg-red */
-.bg-red { background-color: #d73a49 !important; }
+.bg-red { background-color: #b45309 !important; }
 
 /* Set the background to $bg-red-light */
-.bg-red-light { background-color: #ffdce0 !important; }
+.bg-red-light { background-color: #fdebd0 !important; }
 
 /* Set the background to $bg-yellow */
 .bg-yellow { background-color: #ffd33d !important; }
@@ -539,7 +539,7 @@ pre { margin-top: 0; margin-bottom: 0; font-family: "SFMono-Regular", Consolas, 
 .text-blue { color: #0366d6 !important; }
 
 /* Set the text color to $text-red */
-.text-red { color: #cb2431 !important; }
+.text-red { color: #b45309 !important; }
 
 /* Set the text color to $text-gray-light */
 .text-gray-light { color: #6a737d !important; }
@@ -2683,7 +2683,7 @@ pre { margin-top: 0; margin-bottom: 0; font-family: "SFMono-Regular", Consolas, 
 .markdown-body > *:first-child { margin-top: 0 !important; }
 .markdown-body > *:last-child { margin-bottom: 0 !important; }
 .markdown-body a:not([href]) { color: inherit; text-decoration: none; }
-.markdown-body .absent { color: #cb2431; }
+.markdown-body .absent { color: #b45309; }
 .markdown-body .anchor { float: left; padding-right: 4px; margin-left: -20px; line-height: 1; }
 .markdown-body .anchor:focus { outline: none; }
 .markdown-body p, .markdown-body blockquote, .markdown-body ul, .markdown-body ol, .markdown-body dl, .markdown-body table, .markdown-body pre { margin-top: 0; margin-bottom: 16px; }
@@ -2770,13 +2770,13 @@ pre { margin-top: 0; margin-bottom: 0; font-family: "SFMono-Regular", Consolas, 
 
 .highlight .c, .highlight .cd { color: #999988; font-style: italic; }
 
-.highlight .err { color: #a61717; background-color: #e3d2d2; }
+.highlight .err { color: #8a5a00; background-color: #f0e6d2; }
 
-.highlight .gd { color: #000000; background-color: #ffdddd; }
+.highlight .gd { color: #000000; background-color: #fdebd0; }
 
 .highlight .ge { color: #000000; font-style: italic; }
 
-.highlight .gr { color: #aa0000; }
+.highlight .gr { color: #b45309; }
 
 .highlight .gh { color: #999999; }
 
@@ -2790,7 +2790,7 @@ pre { margin-top: 0; margin-bottom: 0; font-family: "SFMono-Regular", Consolas, 
 
 .highlight .gu { color: #aaaaaa; }
 
-.highlight .gt { color: #aa0000; }
+.highlight .gt { color: #b45309; }
 
 .highlight .kc { color: #000000; font-weight: bold; }
 
@@ -2856,11 +2856,11 @@ pre { margin-top: 0; margin-bottom: 0; font-family: "SFMono-Regular", Consolas, 
 
 .highlight .ni { color: #800080; }
 
-.highlight .ne { color: #990000; font-weight: bold; }
+.highlight .ne { color: #8a5a00; font-weight: bold; }
 
-.highlight .nf { color: #990000; font-weight: bold; }
+.highlight .nf { color: #8a5a00; font-weight: bold; }
 
-.highlight .nl { color: #990000; font-weight: bold; }
+.highlight .nl { color: #8a5a00; font-weight: bold; }
 
 .highlight .nn { color: #555555; }
 


### PR DESCRIPTION
## Summary

Re-themes ggordonhall.github.io to comply with the team's **no-red** design constraint (recorded in the Context Tree at `design/NODE.md` — the team considers red bad luck). The site's previous primary accent was `#ef476f` (a red-pink), plus several explicit reds in the utility classes and syntax highlighting.

### Changes (`assets/css/main.css`, `assets/css/style.css`)
- **Primary accent → teal-blue `#118ab2`** (already the site's heading/footer colour), applied to links, the big name banner, publications headings, buttons, stars, bibliography rules, pagination/footer hovers, and `.blankbox`. This unifies the site on its existing non-red identity.
- **Explicit reds → amber/orange**, the conventional non-red signal for warning/error semantics:
  - `#ff3636` (`.red` / `.bg-red` utilities, syntax strings, `.hljs-title`) → `#b45309`
  - GitHub-Primer reds (`#d73a49`, `#cb2431`, `#aa0000`, `#990000`, `#a61717`) and pink tints (`#ffdce0`, `#ffdddd`, `#cea0a5`, `#e3d2d2`) → amber tones
- **Contrast fix:** footer link hover was the red accent on the teal footer; set to `#ffd166` so it stays visible after the accent change.

Verified with a hue sweep that **no red colour values remain** in either stylesheet.

## Test plan
- [ ] Build the Jekyll site and eyeball the homepage, publications, and footer.
- [ ] Confirm the name banner, links, and publication headings read teal-blue (not pink/red).
- [ ] Confirm code blocks / markdown render with amber (not red) for strings/errors.

## Context
Implements the constraint in tree PR ggordonhall/ggordonhall.github.io-tree#1 (merged). Implementation-only change, so no further tree update is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)